### PR TITLE
feat: document desktop setup and configurable AI worker URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,42 @@
 - History panel with undo/redo (path-based snapshots).
 - Real-ESRGAN upscale endpoint with CPU bicubic fallback.
 
+## Desktop
+
+### Install dependencies
+
+```
+cd apps/desktop
+npm install
+```
+
+### Development
+
+```
+npm run dev
+```
+
+### Production build
+
+```
+npm run build
+```
+
+### AI worker URL
+
+The desktop app expects an AI worker running at `http://127.0.0.1:8001`. Set the
+`VITE_AI_WORKER_URL` environment variable to point to a different host or port
+when running or building the app.
+
+### Troubleshooting
+
+- If models are missing, the AI worker will download Real-ESRGAN weights on
+  first use. Without them, a slower CPU bicubic fallback is used.
+- Ensure the AI worker is reachable at the URL above; adjust
+  `VITE_AI_WORKER_URL` if it runs elsewhere.
+- Platform notes: packaging for macOS, Windows or Linux uses
+  `electron-builder` and may require additional system dependencies.
+
 ### Run AI worker (requires models)
 - Install PyTorch matching your CUDA (see PyTorch install guide).
 - `pip install -r apps/ai-workers/requirements.txt`

--- a/apps/desktop/renderer/api.ts
+++ b/apps/desktop/renderer/api.ts
@@ -1,5 +1,7 @@
+const AI_WORKER_URL = import.meta.env.VITE_AI_WORKER_URL ?? 'http://127.0.0.1:8001';
+
 export async function apiRemoveBackground(imagePath: string) {
-  const res = await fetch('http://127.0.0.1:8001/remove-background', {
+  const res = await fetch(`${AI_WORKER_URL}/remove-background`, {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({ image_path: imagePath, preview: false })
@@ -8,7 +10,7 @@ export async function apiRemoveBackground(imagePath: string) {
   return await res.json() as { mask_path: string; cutout_path: string };
 }
 export async function apiInpaint(imagePath: string, polygon: {x:number;y:number}[], prompt: string, strength=0.7) {
-  const res = await fetch('http://127.0.0.1:8001/inpaint', {
+  const res = await fetch(`${AI_WORKER_URL}/inpaint`, {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({ image_path: imagePath, polygon, prompt, strength })
@@ -17,7 +19,7 @@ export async function apiInpaint(imagePath: string, polygon: {x:number;y:number}
   return await res.json() as { output_path: string; mask_path: string };
 }
 export async function apiUpscale(imagePath: string, scale=2) {
-  const res = await fetch('http://127.0.0.1:8001/upscale', {
+  const res = await fetch(`${AI_WORKER_URL}/upscale`, {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({ image_path: imagePath, scale })


### PR DESCRIPTION
## Summary
- add desktop app setup, build, and troubleshooting instructions
- make renderer API use configurable `VITE_AI_WORKER_URL`

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68afe7845db4832fb3158c4cfe3e50c4